### PR TITLE
Add seperate columns for From and To fields; show Date and Time

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -1,4 +1,4 @@
-﻿<!-- Copyright (c) 2016, Dijji, and released under Ms-PL.  This can be found in the root of this distribution.-->
+<!-- Copyright (c) 2016, Dijji, and released under Ms-PL.  This can be found in the root of this distribution.-->
 <Window x:Class="XstReader.MainWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -62,7 +62,7 @@
                                 </DataTemplate>
                             </GridViewColumn.CellTemplate>
                         </GridViewColumn>
-                        <GridViewColumn Width="350" >
+                        <GridViewColumn Width="250" >
                             <GridViewColumn.Header>
                                 <GridViewColumnHeader Tag="Subject" Click="listMessagesColumnHeader_Click">Subject</GridViewColumnHeader>
                             </GridViewColumn.Header>
@@ -74,11 +74,21 @@
                         </GridViewColumn>
                         <GridViewColumn Width="100" >
                             <GridViewColumn.Header>
-                                <GridViewColumnHeader Tag="FromTo" Click="listMessagesColumnHeader_Click">From or To</GridViewColumnHeader>
+                                <GridViewColumnHeader Tag="From" Click="listMessagesColumnHeader_Click">From</GridViewColumnHeader>
                             </GridViewColumn.Header>
                             <GridViewColumn.CellTemplate>
                                 <DataTemplate>
-                                    <TextBlock Text="{Binding Path=FromTo}" />
+                                    <TextBlock Text="{Binding Path=From}"/>
+                                </DataTemplate>
+                            </GridViewColumn.CellTemplate>
+                        </GridViewColumn>
+                        <GridViewColumn Width="100" >
+                            <GridViewColumn.Header>
+                                <GridViewColumnHeader Tag="To" Click="listMessagesColumnHeader_Click">To</GridViewColumnHeader>
+                            </GridViewColumn.Header>
+                            <GridViewColumn.CellTemplate>
+                                <DataTemplate>
+                                    <TextBlock Text="{Binding Path=To}" />
                                 </DataTemplate>
                             </GridViewColumn.CellTemplate>
                         </GridViewColumn>

--- a/View.cs
+++ b/View.cs
@@ -162,7 +162,7 @@ namespace XstReader
         public DateTime? Submitted { get; set; }
         public DateTime? Modified { get; set; }  // When any attachment was last modified
         public DateTime? Date { get { return Received ?? Submitted; } }
-        public string DisplayDate { get { return Date != null ? ((DateTime)Date).ToShortDateString() : "<unknown>"; } }
+        public string DisplayDate { get { return Date != null ? ((DateTime)Date).ToShortDateString() + " " + ((DateTime)Date).ToShortTimeString() : "<unknown>"; } }
         public NID Nid { get; set; }
         public BodyType NativeBody { get; set; }
         public string Body { get; set; }


### PR DESCRIPTION
I found it more useful to see both `From` and `To` fields in the message list.