### PR TITLE
Fix for #8

### DIFF
--- a/XstFile.cs
+++ b/XstFile.cs
@@ -476,14 +476,11 @@ namespace XstReader
 
             if (value != null)
             {
-                value = value.Replace("\r\n", "; ").Replace("\r", "; ").Replace("\n", "; ");
-                if (value.Contains(','))    
+                if (value.Contains(',') || value.Contains('"') || value.Contains("\n") || value.Contains("\n") )    
                 {
                     // We need to quote the value, and therefore get rid of quotes in it
                     // Excel is also fooled by spaces after embedded commas
-                    var val = value.Replace("\"", "'");
-                    while (val.Contains(", "))
-                        val = val.Replace(", ", ",");
+                    var val = value.Replace("\"", "\"\"");
                     sb.Append("\"");
                     sb.Append(EnforceCsvValueLengthLimit(val));
                     sb.Append("\"");

--- a/XstFile.cs
+++ b/XstFile.cs
@@ -362,7 +362,8 @@ namespace XstReader
             var columns = dict.Keys.OrderBy(x => x).ToArray();
 
             // And finally output the CSV file line by line
-            using (var sw = new System.IO.StreamWriter(fileName, false))
+            using (var sw = new System.IO.StreamWriter(fileName, false,  /* Encoding.Default */ System.Text.Encoding.GetEncoding("utf-8") ))
+
             {
                 StringBuilder sb = new StringBuilder();
                 bool hasValue = false;
@@ -476,7 +477,8 @@ namespace XstReader
 
             if (value != null)
             {
-                if (value.Contains(',') || value.Contains('"') || value.Contains("\n") || value.Contains("\n") )    
+                // multilingual character should be quoted, so almost always quotation is necessary
+                // if (value.Contains(',') || value.Contains('"') || value.Contains("\n") || value.Contains("\n") )    
                 {
                     // We need to quote the value, and therefore get rid of quotes in it
                     // Excel is also fooled by spaces after embedded commas
@@ -485,8 +487,8 @@ namespace XstReader
                     sb.Append(EnforceCsvValueLengthLimit(val));
                     sb.Append("\"");
                 }
-                else
-                    sb.Append(EnforceCsvValueLengthLimit(value));
+                // else
+                //    sb.Append(EnforceCsvValueLengthLimit(value));
             }
 
             hasValue = true;


### PR DESCRIPTION
- No replacement about \r \n, instead the column is wrapped by "".
- A doublequote is replaced with two doublequotes.
- No commna replaced because it is not necessary.