### PR TITLE
Add info button

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -61,9 +61,8 @@
         </TreeView>
         <Grid Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="3">
             <StackPanel Grid.Row="1"  Orientation="Horizontal">
-                <Button Content="Open..." Height="20" Width="75" Margin="40,0,0,0" Name="btnOpen" Click="btnOpen_Click" />
+                <Button Content="Open..." Height="20" Width="75" Margin="10,0,0,0" Name="btnOpen" Click="btnOpen_Click" />
                 <TextBlock Name="txtStatus" Margin="10,7,0,0"/>
-                <Button Content="i" Width="20" Margin="150,0,0,0" Click="Button_Click" Height="20" VerticalAlignment="Center" FontWeight="Bold" HorizontalAlignment="Center"/>
             </StackPanel>
         </Grid>
         <GridSplitter Grid.Row="0" Grid.Column="1" Width="3" HorizontalAlignment="Stretch" />
@@ -299,6 +298,7 @@
                               Visibility="{Binding MessagePresent, Converter={StaticResource VisibleIfTrue}}"/>
             <RadioButton x:Name="rbProperties" Content="Properties" Margin="0,7,10,0" Click="rbProperties_Click"
                               Visibility="{Binding MessagePresent, Converter={StaticResource VisibleIfTrue}}"/>
+            <Button Content="i" Width="20" Margin="0,0,5,0" Click="Button_Click" Height="20" VerticalAlignment="Center" FontWeight="Bold" HorizontalAlignment="Right"/>
         </StackPanel>
     </Grid>
 </Window>

--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -1,4 +1,4 @@
-﻿<!-- Copyright (c) 2016, Dijji, and released under Ms-PL.  This can be found in the root of this distribution.-->
+<!-- Copyright (c) 2016, Dijji, and released under Ms-PL.  This can be found in the root of this distribution.-->
 <Window x:Class="XstReader.MainWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -61,8 +61,9 @@
         </TreeView>
         <Grid Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="3">
             <StackPanel Grid.Row="1"  Orientation="Horizontal">
-                <Button Content="Open..." Height="20" Width="75" Margin="10,0,0,0" Name="btnOpen" Click="btnOpen_Click" />
+                <Button Content="Open..." Height="20" Width="75" Margin="40,0,0,0" Name="btnOpen" Click="btnOpen_Click" />
                 <TextBlock Name="txtStatus" Margin="10,7,0,0"/>
+                <Button Content="i" Width="20" Margin="150,0,0,0" Click="Button_Click" Height="20" VerticalAlignment="Center" FontWeight="Bold" HorizontalAlignment="Center"/>
             </StackPanel>
         </Grid>
         <GridSplitter Grid.Row="0" Grid.Column="1" Width="3" HorizontalAlignment="Stretch" />
@@ -290,7 +291,7 @@
         <StackPanel Grid.Column="4" Grid.Row="1" Orientation="Horizontal">
             <Button Content="Save All Attachments..." Height="20" Width="150" Margin="10,0,0,0" Name="btnSaveAllAttachments" Click="btnSaveAllAttachments_Click" 
                         Visibility="{Binding IsFileAttachmentPresent, Converter={StaticResource VisibleIfTrue}}" IsEnabled="{Binding Path=IsFileAttachmentPresent}"/>
-            <Button Content="Close Email" Height="20" Width="75" Margin="10,5,0,0" Name="btnCloseEmail" Click="btnCloseEmail_Click"
+            <Button Content="Close Email" Height="20" Width="75" Margin="10,0,0,0" Name="btnCloseEmail" Click="btnCloseEmail_Click"
                         Visibility="{Binding CanPopMessage, Converter={StaticResource VisibleIfTrue}}" />
         </StackPanel>
         <StackPanel Grid.Column="4" Grid.Row="1" Orientation="Horizontal" HorizontalAlignment="Right">

--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -298,7 +298,7 @@
                               Visibility="{Binding MessagePresent, Converter={StaticResource VisibleIfTrue}}"/>
             <RadioButton x:Name="rbProperties" Content="Properties" Margin="0,7,10,0" Click="rbProperties_Click"
                               Visibility="{Binding MessagePresent, Converter={StaticResource VisibleIfTrue}}"/>
-            <Button Content="i" Width="20" Margin="0,0,5,0" Click="Button_Click" Height="20" VerticalAlignment="Center" FontWeight="Bold" HorizontalAlignment="Right"/>
+            <Button Content="i" Width="20" Margin="0,0,5,0" Click="btnInfo_Click" Height="20" VerticalAlignment="Center" FontWeight="Bold" HorizontalAlignment="Right"/>
         </StackPanel>
     </Grid>
 </Window>

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2016, Dijji, and released under Ms-PL.  This can be found in the root of this distribution. 
+// Copyright (c) 2016, Dijji, and released under Ms-PL.  This can be found in the root of this distribution. 
 
 using SearchTextBox;
 using System;
@@ -36,7 +36,7 @@ namespace XstReader
             this.DataContext = view;
 
             // For testing purposes, use these flags to control the display of print headers
-            //view.DisplayPrintHeaders = true;
+            view.DisplayPrintHeaders = true;
             //view.DisplayEmailType = true;
 
             // Supply the Search control with the list of sections
@@ -890,6 +890,19 @@ namespace XstReader
             OAIF_HIDE_REGISTRATION = 0x00000020,   // Vista+: Hide the "always use this file" checkbox
             OAIF_URL_PROTOCOL = 0x00000040,   // Vista+: cszFile is actually a URI scheme; show handlers for that scheme
             OAIF_FILE_IS_URI = 0x00000080    // Win8+: The location pointed to by the pcszFile parameter is given as a URI
+        }
+
+        private void Button_Click(object sender, RoutedEventArgs e)
+        {
+            string msg = "View Microsoft Outlook Mail files" + Environment.NewLine;
+            msg = msg + Environment.NewLine;
+            string Repository = "https://github.com/Dijji/XstReader";
+            msg = msg + "Repository: " + Repository + Environment.NewLine;
+            msg = msg + "Version: ";
+            //Version version = new Version(Application.ProductVersion);
+            //MessageBox.Show(msg + version.ToString(), "About XstReader");
+            MessageBox.Show(msg, "About XstReader");
+                        
         }
     }
 }

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -895,7 +895,7 @@ namespace XstReader
 
         private void btnInfo_Click(object sender, RoutedEventArgs e)
         {
-            Version version = new Version(Application.ProductVersion);
+            Version version = System.Reflection.Assembly.GetExecutingAssembly().GetName().Version;
             string Repository = "https://github.com/Dijji/XstReader";
 
             StringBuilder msg = new StringBuilder(100);

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -36,7 +36,7 @@ namespace XstReader
             this.DataContext = view;
 
             // For testing purposes, use these flags to control the display of print headers
-            view.DisplayPrintHeaders = true;
+            //view.DisplayPrintHeaders = true;
             //view.DisplayEmailType = true;
 
             // Supply the Search control with the list of sections
@@ -892,17 +892,29 @@ namespace XstReader
             OAIF_FILE_IS_URI = 0x00000080    // Win8+: The location pointed to by the pcszFile parameter is given as a URI
         }
 
-        private void Button_Click(object sender, RoutedEventArgs e)
+        private void btnInfo_Click(object sender, RoutedEventArgs e)
         {
-            string msg = "View Microsoft Outlook Mail files" + Environment.NewLine;
-            msg = msg + Environment.NewLine;
+            MessageBoxResult Option;
             string Repository = "https://github.com/Dijji/XstReader";
-            msg = msg + "Repository: " + Repository + Environment.NewLine;
-            msg = msg + "Version: ";
+            string msg = "View Microsoft Outlook Mail files" + Environment.NewLine
+            + Environment.NewLine
+            + "Version: " + Environment.NewLine
+            + Environment.NewLine
+            + Environment.NewLine
+            + "Open Repository: " + Repository;
             //Version version = new Version(Application.ProductVersion);
             //MessageBox.Show(msg + version.ToString(), "About XstReader");
-            MessageBox.Show(msg, "About XstReader");
-                        
+            Option = MessageBox.Show(
+                msg,
+                "About XstReader",
+                MessageBoxButton.YesNo,
+                MessageBoxImage.Question,
+                MessageBoxResult.No);
+            
+            if (Option == MessageBoxResult.Yes)
+            {
+                Process.Start(Repository);
+            }
         }
     }
 }

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -8,6 +8,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
+using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using System.Windows;
@@ -894,27 +895,17 @@ namespace XstReader
 
         private void btnInfo_Click(object sender, RoutedEventArgs e)
         {
-            MessageBoxResult Option;
+            Version version = new Version(Application.ProductVersion);
             string Repository = "https://github.com/Dijji/XstReader";
-            string msg = "View Microsoft Outlook Mail files" + Environment.NewLine
-            + Environment.NewLine
-            + "Version: " + Environment.NewLine
-            + Environment.NewLine
-            + Environment.NewLine
-            + "Open Repository: " + Repository;
-            //Version version = new Version(Application.ProductVersion);
-            //MessageBox.Show(msg + version.ToString(), "About XstReader");
-            Option = MessageBox.Show(
-                msg,
-                "About XstReader",
-                MessageBoxButton.YesNo,
-                MessageBoxImage.Question,
-                MessageBoxResult.No);
-            
-            if (Option == MessageBoxResult.Yes)
-            {
-                Process.Start(Repository);
-            }
+
+            StringBuilder msg = new StringBuilder(100);
+            msg.AppendLine("View Microsoft Outlook Mail files");
+            msg.Append("Version: ");
+            msg.AppendLine(version.ToString());
+            msg.Append("Repository: ");
+            msg.AppendLine(Repository);
+
+            MessageBox.Show(msg.ToString(), "About XstReader");
         }
     }
 }


### PR DESCRIPTION
In development

Reply to: https://github.com/Dijji/XstReader/issues/18#issuecomment-563249377

![InfoTool](https://user-images.githubusercontent.com/11288701/70472808-ddf75280-1b23-11ea-9951-4bf526153d6e.png)

Objective was to put an icon to the left of the open button. Thinking Visual Studio Image Library 2017 ![StatusInformation](https://user-images.githubusercontent.com/11288701/70475728-45fc6780-1b29-11ea-903e-7ef3be047f7a.png) or maybe ![InformationSymbol](https://user-images.githubusercontent.com/11288701/70475911-b5725700-1b29-11ea-95f7-01bb0291722c.png) but bold text works. Initial thought was a form, then inspired by app minimalist approach changed to a MsgBox. Issues:
* Still not clear how to get the version variable which must come from compiler
* Open is first button and haven't found where order is assigned
* Possibly drop icon on button or maybe it should be a tool button
* Wondering if whole status bar should be a toolbar at top of window, agree it's secondary content

Hmm ... A full-blown settings form is a different scope