### PR TITLE
Correct definition of FileHeader2Unicode.rgbReserved

### DIFF
--- a/LayoutsU.cs
+++ b/LayoutsU.cs
@@ -30,7 +30,7 @@ namespace XstReader
         public fixed Byte rgbFP[128];
         public Byte bSentinel;
         public EbCryptMethod bCryptMethod;
-        public UInt32 rgbReserved;
+        public UInt16 rgbReserved;
         public UInt64 bidNextB;
         public UInt32 dwCRCFull;
         public UInt32 rgbReserved2;


### PR DESCRIPTION
[MS-PST] 2.2.2.6 HEADER: rgbReserved (2 bytes): Reserved; MUST be set to zero.